### PR TITLE
On complete in use animate fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.1",
     "@types/react": "^16.9.35",
     "@types/react-test-renderer": "^16.9.2",
     "@typescript-eslint/eslint-plugin": "^3.0.0",

--- a/src/useAnimate.test.tsx
+++ b/src/useAnimate.test.tsx
@@ -3,10 +3,12 @@ import useAnimate from './useAnimate';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 
+jest.useFakeTimers('modern');
+
 let UseAnimate;
 
 describe('useAnimate', () => {
-  let componentStyle;
+  let componentStyle, onComplete;
 
   const TestHook = ({
     callback,
@@ -23,8 +25,13 @@ describe('useAnimate', () => {
   };
 
   beforeEach(() => {
+    onComplete = jest.fn();
+
     TestComponent(() => {
-      UseAnimate = useAnimate({ end: { opacity: 1 } });
+      UseAnimate = useAnimate({
+        end: { opacity: 1 },
+        onComplete: () => onComplete(),
+      });
       return UseAnimate;
     });
 
@@ -43,5 +50,25 @@ describe('useAnimate', () => {
       opacity: 1,
       transition: 'all 0.3s linear 0s',
     });
+  });
+
+  it('should call onComplete only when isPlaying', () => {
+    onComplete.mockImplementation(() => {
+      act(() => {
+        UseAnimate.play(false);
+      });
+    });
+
+    act(() => {
+      UseAnimate.play(true);
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/useAnimate.ts
+++ b/src/useAnimate.ts
@@ -49,30 +49,33 @@ export default function useAnimate(props: UseAnimateProps): {
         }
 
         if (complete) {
-          setAnimate({
+          setAnimate((animate) => ({
             ...animate,
             style: complete,
-          });
+          }));
         }
       }, secToMs(delay + duration));
     }
 
     return () =>
       onCompleteTimeRef.current && clearTimeout(onCompleteTimeRef.current);
-  }, [isPlaying, onComplete]);
+  }, [animate, complete, delay, duration, isPlaying, onComplete]);
 
   return {
     isPlaying,
     style,
-    play: React.useCallback((isPlaying) => {
-      setAnimate({
-        ...animate,
-        style: {
-          ...(isPlaying ? end : start),
-          transition,
-        },
-        isPlaying,
-      });
-    }, []),
+    play: React.useCallback(
+      (isPlaying) => {
+        setAnimate((animate) => ({
+          ...animate,
+          style: {
+            ...(isPlaying ? end : start),
+            transition,
+          },
+          isPlaying,
+        }));
+      },
+      [end, start, transition],
+    ),
   };
 }

--- a/src/useAnimate.ts
+++ b/src/useAnimate.ts
@@ -42,7 +42,7 @@ export default function useAnimate(props: UseAnimateProps): {
   const onCompleteTimeRef = React.useRef<NodeJS.Timeout>();
 
   React.useEffect(() => {
-    if ((onCompleteTimeRef.current || complete) && isPlaying) {
+    if ((onComplete || complete) && isPlaying) {
       onCompleteTimeRef.current = setTimeout(() => {
         if (onComplete) {
           onComplete();
@@ -59,7 +59,7 @@ export default function useAnimate(props: UseAnimateProps): {
 
     return () =>
       onCompleteTimeRef.current && clearTimeout(onCompleteTimeRef.current);
-  }, [isPlaying]);
+  }, [isPlaying, onComplete]);
 
   return {
     isPlaying,

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,16 +499,6 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
-
 "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
@@ -680,14 +670,6 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^1.1.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
-  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "*"
-    "@types/istanbul-lib-report" "*"
-
 "@types/istanbul-reports@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz#9153fe98bba2bd565a63add9436d6f0d7f8468ff"
@@ -695,13 +677,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^25.2.3":
-  version "25.2.3"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
-  integrity sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==
+"@types/jest@^26.0.1":
+  version "26.0.24"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
+  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
   dependencies:
-    jest-diff "^25.2.1"
-    pretty-format "^25.2.1"
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
 
 "@types/json-schema@^7.0.3":
   version "7.0.11"
@@ -1319,14 +1301,6 @@ chalk@^2.0.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1685,11 +1659,6 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
-
-diff-sequences@^25.2.6:
-  version "25.2.6"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
-  integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -3125,17 +3094,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^25.2.1:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
-  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
-  dependencies:
-    chalk "^3.0.0"
-    diff-sequences "^25.2.6"
-    jest-get-type "^25.2.6"
-    pretty-format "^25.5.0"
-
-jest-diff@^26.6.2:
+jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -3187,11 +3146,6 @@ jest-environment-node@^26.6.2:
     "@types/node" "*"
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
-
-jest-get-type@^25.2.6:
-  version "25.2.6"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
-  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
 jest-get-type@^26.3.0:
   version "26.3.0"
@@ -4365,17 +4319,7 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.0.tgz#a4fdae07e5596c51c9857ea676cd41a0163879d6"
   integrity sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==
 
-pretty-format@^25.2.1, pretty-format@^25.5.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
-  dependencies:
-    "@jest/types" "^25.5.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
-
-pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -4469,7 +4413,7 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.8.6:
+react-is@^16.13.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
There are 2 fixes in this PR:

1. The useEffect condition should run if `onComplete || complete`, not `onCompleteTimeRef.current || complete`.
  - This is because `onCompleteTimeRef.current` is ALWAYS truthy after the first time `useEffect` is ran, because we never set `onCompleteTimeRef.current` to anything falsey.  We do clear the timeout, but that doesn't change the value of `onCompleteTimeRef.current`, which is just a number.
  - This also brings this file into parity with what is happening in the Animate component here: https://github.com/beekai-oss/react-simple-animate/blob/master/src/animate.tsx#L46
2. When updating state, and wanting to include some prior state in that update, then you should always use the callback version of `setState`.  See: https://reactjs.org/docs/hooks-reference.html#functional-updates.
  - In this case, it is particularly problematic because we're calling `setAnimate` in a callback of a `setTimeout`, so it is retrieving quite stale state.  This is causing me problems when implementing this hook.