### PR TITLE
Fix license (`Mit` → `MIT`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "repository": "https://github.com/bluebill1049/react-simple-animation.git",
   "homepage": "https://react-simple-animate.now.sh",
   "author": "beier luo",
-  "license": "Mit",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/bluebill1049/react-simple-animate/issues"
   },


### PR DESCRIPTION
Our build tooling (i.e. [webpack-license-plugin](https://github.com/codepunkt/webpack-license-plugin)) complains 

```
WebpackLicensePlugin: License "Mit" for react-simple-animate@3.5.2 is not a valid SPDX expression!
```

and it's correct, `Mit` (lowercase `it`) isn't [in this list](https://spdx.org/licenses/).

Hence fix it, assuming the [MIT License](https://en.wikipedia.org/wiki/MIT_License) was meant.

---

Thanks for creating this! :)